### PR TITLE
Do not cache dependencies in package

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -14,12 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Cache dependencies
-      uses: actions/cache@v1
-      with:
-        path: ~/.composer/cache/files
-        key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
-
     - name: Validate composer.json and composer.lock
       run: composer validate
 


### PR DESCRIPTION
Due to the tests we are doing (generating files that go into the `vendor/orchestra/testbench-core/laravel` folder) don't cache dependencies to avoid issues